### PR TITLE
Improve translation speed by apply unscope to only necessary table

### DIFF
--- a/lib/translation_io/client/base_operation/dump_db_text_keys_step.rb
+++ b/lib/translation_io/client/base_operation/dump_db_text_keys_step.rb
@@ -35,11 +35,11 @@ module TranslationIO
 
         def extracted_db_entries
           entries = []
-
+          unscoped_item = ["Phase", "Section", "Question"]
           @db_fields.keys.each do |table_name|
             table = table_name.constantize
             @db_fields[table_name].each do |column_name|
-              db_strings = table.distinct.pluck(column_name)
+              db_strings = if unscoped_item.include? table_name.to_s then table.unscoped.distinct.pluck(column_name) else table.distinct.pluck(column_name) end
               entries += db_strings
             end
           end

--- a/lib/translation_io/client/base_operation/update_pot_file_step.rb
+++ b/lib/translation_io/client/base_operation/update_pot_file_step.rb
@@ -16,6 +16,7 @@ module TranslationIO
           TranslationIO.info "Updating POT file."
 
           FileUtils.mkdir_p(File.dirname(@pot_path))
+          TranslationIO.info "source files:" + @source_files.to_s
           GetText::Tools::XGetText.run(*@source_files, '-o', @pot_path,
                                        '--msgid-bugs-address', TranslationIO.config.pot_msgid_bugs_address,
                                        '--package-name',       TranslationIO.config.pot_package_name,


### PR DESCRIPTION
Tested on staging and uat:

1) Although this is not the fix for issue314 (), adding the `unscoped` filter to `phase`, `section` and `question` can help speed up the overall translation process.

2) Add information to show all the source files that need to be translated, so that in the future, we can examine the translation load easier.