### PR TITLE
Merge fix/broken_db_fake_method_calls Into integration

### DIFF
--- a/lib/translation_io/client/base_operation/dump_db_text_keys_step.rb
+++ b/lib/translation_io/client/base_operation/dump_db_text_keys_step.rb
@@ -39,7 +39,7 @@ module TranslationIO
           @db_fields.keys.each do |table_name|
             table = table_name.constantize
             @db_fields[table_name].each do |column_name|
-              db_strings = table.unscoped.distinct.pluck(column_name)
+              db_strings = table.distinct.pluck(column_name)
               entries += db_strings
             end
           end

--- a/lib/translation_io/client/base_operation/dump_db_text_keys_step.rb
+++ b/lib/translation_io/client/base_operation/dump_db_text_keys_step.rb
@@ -29,7 +29,6 @@ module TranslationIO
         # multi-line strings
         def escape_entry(entry)          
           entry.gsub('"', '\"')
-               .gsub("\r\n", '\r\n')
                .gsub("\n", '\n')
         end
 

--- a/lib/translation_io/client/base_operation/dump_db_text_keys_step.rb
+++ b/lib/translation_io/client/base_operation/dump_db_text_keys_step.rb
@@ -39,7 +39,7 @@ module TranslationIO
           @db_fields.keys.each do |table_name|
             table = table_name.constantize
             @db_fields[table_name].each do |column_name|
-              db_strings = table.distinct.pluck(column_name)
+              db_strings = table.unscoped.distinct.pluck(column_name)
               entries += db_strings
             end
           end

--- a/lib/translation_io/client/base_operation/dump_db_text_keys_step.rb
+++ b/lib/translation_io/client/base_operation/dump_db_text_keys_step.rb
@@ -35,11 +35,11 @@ module TranslationIO
 
         def extracted_db_entries
           entries = []
-
+          unscoped_item = ["Phase", "Section", "Question"]
           @db_fields.keys.each do |table_name|
             table = table_name.constantize
             @db_fields[table_name].each do |column_name|
-              db_strings = table.distinct.pluck(column_name)
+              db_strings = if unscoped_item.include? table_name.to_s then table.unscoped.distinct.pluck(column_name) else table.distinct.pluck(column_name) end
               entries += db_strings
             end
           end

--- a/lib/translation_io/client/base_operation/update_pot_file_step.rb
+++ b/lib/translation_io/client/base_operation/update_pot_file_step.rb
@@ -16,6 +16,7 @@ module TranslationIO
           TranslationIO.info "Updating POT file."
 
           FileUtils.mkdir_p(File.dirname(@pot_path))
+          TranslationIO.info "source files:" + @source_files.to_s
           GetText::Tools::XGetText.run(*@source_files, '-o', @pot_path,
                                        '--msgid-bugs-address', TranslationIO.config.pot_msgid_bugs_address,
                                        '--package-name',       TranslationIO.config.pot_package_name,


### PR DESCRIPTION
`fix/broken_db_fake_method_calls` is the branch currently being referenced within DMP Assistant's Gemfile. This PR is part of an effort to better organise the workflow for this repo.